### PR TITLE
Add ability to filter out stdOut and stdErr

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,11 +5,13 @@ module.exports = {
     es2020: true,
     jest: true,
   },
-  extends: ['eslint:recommended'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 'latest',
   },
   plugins: ['@typescript-eslint'],
-  rules: {},
+  rules: {
+    // "no-unused-vars": "off",
+  },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,5 @@ module.exports = {
     ecmaVersion: 'latest',
   },
   plugins: ['@typescript-eslint'],
-  rules: {
-    // "no-unused-vars": "off",
-  },
+  rules: {},
 };

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ scenarios/*/build.js
 !.yarn/sdks
 !.yarn/versions
 .pnp.*
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ child.on('exit', ({ code, logPath, removeLog }) => {
 | `logPath` | string | Path to the generated log file. |
 | `logPrefix` | string | Convenience option to `logPath` (ignored if `logPath` exists). The path to the log will be `/tmp/${logPath}/${Date.now}. defaults to `log`. |
 | `env` | object | Environment variables for the process (it already includes process.env). |
+| `filterStdOut` | `(chunk: string) => string` | Function to filter out parts of the output that's sent to stdout |
+| `filterStdErr` | `(chunk: string) => string` | Function to filter out parts of the output that's sent to stderr |

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -5,6 +5,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
+    "chalk": "^4.1.0",
     "log-command": "workspace:*"
   },
   "devDependencies": {

--- a/packages/example/src/index.ts
+++ b/packages/example/src/index.ts
@@ -2,11 +2,11 @@ import { exec } from 'child_process';
 import runCommand from 'log-command';
 import { join } from 'path';
 
-const filterOutDebugLogs = (chunk: string) => !/^\[debug\]/.test(chunk);
+const filterOutDebugLogs = (str: string) => str.replace(/[\n\r]{0,1}\[debug\].*\[\/debug\][\n\r]{0,1}/s, '');
 
 const fileToRun = join(__dirname, 'runExample.ts');
 
-const child = runCommand('yarn', ['ts-node', fileToRun], { logPrefix: 'test', filter: filterOutDebugLogs });
+const child = runCommand('yarn', ['ts-node', fileToRun], { logPrefix: 'test', filterStdOut: filterOutDebugLogs });
 
 child.on('exit', ({ code, logPath, removeLog }) => {
   if (code !== 0) {

--- a/packages/example/src/index.ts
+++ b/packages/example/src/index.ts
@@ -1,10 +1,17 @@
+import { exec } from 'child_process';
 import runCommand from 'log-command';
+import { join } from 'path';
 
-const child = runCommand('rm', ['-i', '*.txt'], { logPrefix: 'test' });
+const filterOutDebugLogs = (chunk: string) => !/^\[debug\]/.test(chunk);
+
+const fileToRun = join(__dirname, 'runExample.ts');
+
+const child = runCommand('yarn', ['ts-node', fileToRun], { logPrefix: 'test', filter: filterOutDebugLogs });
 
 child.on('exit', ({ code, logPath, removeLog }) => {
   if (code !== 0) {
     console.error(`Log saved in ${logPath}`);
+    exec(`open -R ${logPath}`);
   } else {
     void removeLog();
   }

--- a/packages/example/src/runExample.ts
+++ b/packages/example/src/runExample.ts
@@ -1,0 +1,10 @@
+import { exit } from "process";
+
+export function main() {
+  console.log('Hello');
+  console.log('[debug] here is some debug message');
+  console.log('World');
+  exit(0);
+}
+
+main();

--- a/packages/example/src/runExample.ts
+++ b/packages/example/src/runExample.ts
@@ -1,10 +1,11 @@
-import { exit } from "process";
+import chalk from 'chalk';
+import { exit } from 'process';
 
 export function main() {
   console.log('Hello');
-  console.log('[debug] here is some debug message');
+  console.log(chalk.dim('[debug] here is some debug message [/debug]'));
   console.log('World');
-  exit(0);
+  exit(1);
 }
 
 main();

--- a/packages/log-command/README.md
+++ b/packages/log-command/README.md
@@ -26,3 +26,5 @@ child.on('exit', ({ code, logPath, removeLog }) => {
 | `logPath` | string | Path to the generated log file. |
 | `logPrefix` | string | Convenience option to `logPath` (ignored if `logPath` exists). The path to the log will be `/tmp/${logPath}/${Date.now}. defaults to `log`. |
 | `env` | object | Environment variables for the process (it already includes process.env). |
+| `filterStdOut` | `(chunk: string) => string` | Function to filter out parts of the output that's sent to stdout |
+| `filterStdErr` | `(chunk: string) => string` | Function to filter out parts of the output that's sent to stderr |

--- a/packages/log-command/package.json
+++ b/packages/log-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log-command",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "This small script facilitates obtaining a log when running a command.",
   "repository": {
     "type": "git",

--- a/packages/log-command/src/filterStream.ts
+++ b/packages/log-command/src/filterStream.ts
@@ -1,0 +1,13 @@
+import { Transform } from 'stream';
+
+export const createFilterStream = (filter: (chunk: string) => string) =>
+  new Transform({
+    transform: (chunk, _, next) => {
+      const result = filter(chunk.toString());
+      if (result !== '') {
+        next(null, result);
+      } else {
+        next();
+      }
+    },
+  });

--- a/packages/log-command/src/index.ts
+++ b/packages/log-command/src/index.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process';
 import { createWriteStream, rm } from 'fs';
-import { EventEmitter } from 'stream';
+import { EventEmitter, Transform } from 'stream';
 import { promisify } from 'util';
 
 type ExitOptions = {
@@ -10,11 +10,8 @@ type ExitOptions = {
 };
 
 interface Emitter extends EventEmitter {
-  // eslint-disable-next-line no-unused-vars
   emit(eventName: 'exit', options: ExitOptions): boolean;
-  // eslint-disable-next-line no-unused-vars
   on(event: 'exit', listener: (options: ExitOptions) => void): this;
-  // eslint-disable-next-line no-unused-vars
   once(event: 'exit', listener: (options: ExitOptions) => void): this;
 }
 
@@ -22,12 +19,18 @@ type CommandOptions = {
   logPath?: string;
   logPrefix?: string;
   env?: Record<string, string>;
+  filter?: (chunk: string) => boolean;
 };
 
 function runCommand(
   command: string,
   args: string[] = [],
-  { logPath: userLogPath, logPrefix = 'log', env = {} }: CommandOptions = {},
+  {
+    logPath: userLogPath,
+    logPrefix = 'log',
+    env = {},
+    filter = () => true,
+  }: CommandOptions = {},
 ) {
   const emitter: Emitter = new EventEmitter();
   const logPath = userLogPath ?? `/tmp/${logPrefix}-${Date.now()}`;
@@ -40,12 +43,23 @@ function runCommand(
     shell: '/bin/bash',
     stdio: ['inherit', 'pipe', 'pipe'],
   });
+  
+  const filterStream = new Transform({
+    transform: (chunk, _encoding, next) => {
+      console.log(chunk);
+      // console.error(`** chunk ${chunk.toString()} filter ${filter(chunk.toString())}**`);
+      if (filter(chunk.toString())) {
+        return next(null, chunk);
+      }
+      next();
+    },
+  });
 
-  child.stdout.pipe(process.stdout, { end: false });
   child.stdout.pipe(logStream, { end: false });
-
-  child.stderr.pipe(process.stderr, { end: false });
+  child.stdout.pipe(filterStream, { end: false }).pipe(process.stdout, { end: false });
+  
   child.stderr.pipe(logStream, { end: false });
+  child.stderr.pipe(filterStream, { end: false }).pipe(process.stderr, { end: false });
 
   const removeLog = () => promisify(rm)(logPath);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3968,6 +3968,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example@workspace:packages/example"
   dependencies:
+    chalk: ^4.1.0
     log-command: "workspace:*"
     ts-node: ^10.8.0
   languageName: unknown


### PR DESCRIPTION
Two new options added:`filterStdOut` and `filterStdErr`.
Useful when you want to remove part of the output that is sent to `stdOut` or `stdErr`